### PR TITLE
feat: add trade completed event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - overlore-0.3.0
   pull_request:
     branches:
       - main
+      - overlore-0.3.0
 
 jobs:
   test:
@@ -23,7 +25,7 @@ jobs:
 
       - name: Download Dojo release artifact
         run: |
-          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v0.4.0/dojo_v0.4.0_linux_amd64.tar.gz
+          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v0.4.1/dojo_v0.4.1_linux_amd64.tar.gz
           tar -xzf dojo-linux-x86_64.tar.gz
           sudo mv sozo /usr/local/bin/
 

--- a/contracts/src/systems/npc/tests/npc_ownership_tests.cairo
+++ b/contracts/src/systems/npc/tests/npc_ownership_tests.cairo
@@ -13,8 +13,8 @@ use core::option::OptionTrait;
 
 use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 
-use eternum::systems::test::contracts::realm::test_realm_systems;
-use eternum::systems::test::interface::realm::{
+use eternum::systems::realm::contracts::realm_systems;
+use eternum::systems::realm::interface::{
     IRealmSystemsDispatcher,
     IRealmSystemsDispatcherTrait,
 };
@@ -52,7 +52,7 @@ fn test_ownership() {
 
     // set realm entity
     let realm_systems_address 
-        = deploy_system(test_realm_systems::TEST_CLASS_HASH);
+        = deploy_system(realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -61,7 +61,6 @@ fn test_ownership() {
     let realm_entity_id = realm_systems_dispatcher.create(
         world,
         1, // realm id
-        starknet::get_contract_address(), // owner
         0x209, // resource_types_packed // 2,9 // stone and gold
         2, // resource_types_count
         5, // cities
@@ -70,6 +69,7 @@ fn test_ownership() {
         5, // regions
         1, // wonder
         1, // order
+        99, // order_hyperstructure_id
         Position { x: 1, y: 1, entity_id: 1_u128 }, // position  
                 // x needs to be > 470200 to get zone
     );

--- a/contracts/src/systems/npc/tests/npc_spawn_test.cairo
+++ b/contracts/src/systems/npc/tests/npc_spawn_test.cairo
@@ -12,9 +12,11 @@ use core::option::OptionTrait;
 
 use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 
-use eternum::systems::test::contracts::realm::test_realm_systems;
-use eternum::systems::test::interface::realm::{
-    IRealmSystemsDispatcher, IRealmSystemsDispatcherTrait,
+use eternum::systems::realm::contracts::realm_systems;
+
+use eternum::systems::realm::interface::{
+    IRealmSystemsDispatcher,
+    IRealmSystemsDispatcherTrait,
 };
 
 
@@ -38,7 +40,7 @@ fn test_spawning() {
     npc_config_dispatcher.set_spawn_config(world, 100);
 
     // set realm entity
-    let realm_systems_address = deploy_system(test_realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -48,7 +50,6 @@ fn test_spawning() {
         .create(
             world,
             1, // realm id
-            starknet::get_contract_address(), // owner
             0x209, // resource_types_packed // 2,9 // stone and gold
             2, // resource_types_count
             5, // cities
@@ -57,6 +58,7 @@ fn test_spawning() {
             5, // regions
             1, // wonder
             1, // order
+            99, // order_hyperstructure_id
             Position { x: 1, y: 1, entity_id: 1_u128 }, // position  
         // x needs to be > 470200 to get zone
         );

--- a/contracts/src/systems/resources/contracts.cairo
+++ b/contracts/src/systems/resources/contracts.cairo
@@ -420,7 +420,28 @@ mod resource_systems {
             resource_chest
 
         }
+        
+        fn get_contents(world: IWorldDispatcher, chest_id: u128) -> Span<(u8, u128)>{
+            let mut resources: Array<(u8, u128)> = array![];
+            let resource_chest = get!(world, chest_id, ResourceChest);
+            let mut resource_chest_weight = get!(world, chest_id, Weight);
+            
+            if (resource_chest_weight.value == 0) {
+                return resources.span();
+            }
 
+            let mut index = 0;
+            loop {
+                if index == resource_chest.resources_count {
+                    break ();
+                }
+                let detached_resource = get!(world, (chest_id, index), DetachedResource);
+                resources.append((detached_resource.resource_type, detached_resource.resource_amount));
+                index += 1;
+            };
+
+            return resources.span();
+        }
 
         fn lock_until(world: IWorldDispatcher, entity_id: u128, ts: u64) {
 

--- a/contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
@@ -340,4 +340,16 @@ mod inventory_transfer_system_tests {
 
     }
 
+    #[test]
+    #[available_gas(30000000000000)]
+    fn test_get_contents() {
+        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+            = setup();
+        
+        let resources = InternalResourceChestSystemsImpl::get_contents(world, chest_id);
+        assert(
+            resources == array![(ResourceTypes::STONE, 1000), (ResourceTypes::GOLD, 1000),].span(), 'invalid resources'
+        );
+    }
+
 }

--- a/contracts/src/systems/trade/contracts/trade_systems.cairo
+++ b/contracts/src/systems/trade/contracts/trade_systems.cairo
@@ -33,7 +33,22 @@ mod trade_systems {
     use eternum::constants::{REALM_ENTITY_TYPE, WORLD_CONFIG_ID, FREE_TRANSPORT_ENTITY_TYPE};
 
     use core::poseidon::poseidon_hash_span;
+    
+    #[derive(Drop, starknet::Event)]
+    struct TradeCompleted {
+        #[key]
+        trade_id: u128,
+        maker_id: u128,
+        taker_id: u128,
+        maker_resources: Span<(u8, u128)>,
+        taker_resources: Span<(u8, u128)>
+    }
 
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        TradeCompleted: TradeCompleted,
+    }
 
     #[external(v0)]
     impl TradeSystemsImpl of ITradeSystems<ContractState> {
@@ -278,8 +293,16 @@ mod trade_systems {
                 ));
             };
 
-    
-            
+
+            emit!(world, TradeCompleted {
+                trade_id, 
+                maker_id: trade.maker_id,
+                taker_id, 
+                maker_resources: resource_chest::get_contents(world, trade.maker_resource_chest_id),
+                taker_resources: resource_chest::get_contents(world, trade.taker_resource_chest_id),
+
+            });
+
 
             /////////  Update Trade   ///////////////
             //////////////////////////////////////////

--- a/contracts/src/systems/trade/contracts/trade_systems.cairo
+++ b/contracts/src/systems/trade/contracts/trade_systems.cairo
@@ -35,19 +35,20 @@ mod trade_systems {
     use core::poseidon::poseidon_hash_span;
     
     #[derive(Drop, starknet::Event)]
-    struct TradeCompleted {
+    struct OrderAccepted {
         #[key]
         trade_id: u128,
         maker_id: u128,
         taker_id: u128,
         maker_resources: Span<(u8, u128)>,
-        taker_resources: Span<(u8, u128)>
+        taker_resources: Span<(u8, u128)>,
+        timestamp: u64
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        TradeCompleted: TradeCompleted,
+        OrderAccepted: OrderAccepted,
     }
 
     #[external(v0)]
@@ -294,13 +295,13 @@ mod trade_systems {
             };
 
 
-            emit!(world, TradeCompleted {
+            emit!(world, OrderAccepted {
                 trade_id, 
                 maker_id: trade.maker_id,
                 taker_id, 
                 maker_resources: resource_chest::get_contents(world, trade.maker_resource_chest_id),
                 taker_resources: resource_chest::get_contents(world, trade.taker_resource_chest_id),
-
+                timestamp: ts
             });
 
 

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -3500,7 +3500,7 @@
     {
       "name": "eternum::systems::trade::contracts::trade_systems::trade_systems",
       "address": "0x63cbe849cf6325e727a8d6f82f25fad7dc7eb9433767f5c1b8c59189e36c9b6",
-      "class_hash": "0x5408a56f824e45f1d27d1b99ad35163e92fbc3ae8388b23643fb12b0e50229c",
+      "class_hash": "0x18299ae9174d4103688386a1a73c86062a69520651a57a4cadf3657a978c5da",
       "abi": [
         {
           "type": "impl",
@@ -3695,7 +3695,7 @@
         },
         {
           "type": "event",
-          "name": "eternum::systems::trade::contracts::trade_systems::trade_systems::TradeCompleted",
+          "name": "eternum::systems::trade::contracts::trade_systems::trade_systems::OrderAccepted",
           "kind": "struct",
           "members": [
             {
@@ -3722,6 +3722,11 @@
               "name": "taker_resources",
               "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>",
               "kind": "data"
+            },
+            {
+              "name": "timestamp",
+              "type": "core::integer::u64",
+              "kind": "data"
             }
           ]
         },
@@ -3736,8 +3741,8 @@
               "kind": "nested"
             },
             {
-              "name": "TradeCompleted",
-              "type": "eternum::systems::trade::contracts::trade_systems::trade_systems::TradeCompleted",
+              "name": "OrderAccepted",
+              "type": "eternum::systems::trade::contracts::trade_systems::trade_systems::OrderAccepted",
               "kind": "nested"
             }
           ]

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -3500,7 +3500,7 @@
     {
       "name": "eternum::systems::trade::contracts::trade_systems::trade_systems",
       "address": "0x63cbe849cf6325e727a8d6f82f25fad7dc7eb9433767f5c1b8c59189e36c9b6",
-      "class_hash": "0x2cc28709c89ec4b37e17ee24865cca41a494cef8734890830d66d8135864ac6",
+      "class_hash": "0x5408a56f824e45f1d27d1b99ad35163e92fbc3ae8388b23643fb12b0e50229c",
       "abi": [
         {
           "type": "impl",
@@ -3695,12 +3695,49 @@
         },
         {
           "type": "event",
+          "name": "eternum::systems::trade::contracts::trade_systems::trade_systems::TradeCompleted",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "trade_id",
+              "type": "core::integer::u128",
+              "kind": "key"
+            },
+            {
+              "name": "maker_id",
+              "type": "core::integer::u128",
+              "kind": "data"
+            },
+            {
+              "name": "taker_id",
+              "type": "core::integer::u128",
+              "kind": "data"
+            },
+            {
+              "name": "maker_resources",
+              "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>",
+              "kind": "data"
+            },
+            {
+              "name": "taker_resources",
+              "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
           "name": "eternum::systems::trade::contracts::trade_systems::trade_systems::Event",
           "kind": "enum",
           "variants": [
             {
               "name": "UpgradeableEvent",
               "type": "dojo::components::upgradeable::upgradeable::Event",
+              "kind": "nested"
+            },
+            {
+              "name": "TradeCompleted",
+              "type": "eternum::systems::trade::contracts::trade_systems::trade_systems::TradeCompleted",
               "kind": "nested"
             }
           ]

--- a/system_up.sh
+++ b/system_up.sh
@@ -1,44 +1,52 @@
 #!/bin/bash
 set -e
 
+SERVICES=("torii" "lore-machine" "katana")
+
 help() {
-	echo -e "Usage: $(basename $0) <command>\ncommand:\n  -start [service1 service2 ...]: starts all services if no service(s) name(s) is/are passed\n  -stop [service1 service2 ...]: stops all services if no service(s) name(s) is/are passed\n  -restart_service <service>: rebuilds and restarts a particular service\n  -restart: restarts all services\n  -prune: clear the system of all images, volumes, networks, containers, etc. (!this will remove ALL docker data)\n  -clean_cache: cleans the client's cached files (node_modules and bun cache)\n  -build_client: builds all files necessary for the client, you still need to run it yourself"
+	echo -e "Usage: $(basename $0) <command>\ncommand:\n  -start [service1 service2 ...]: starts all services if no service(s) name(s) is/are passed\n  -stop [service1 service2 ...]: stops all services if no service(s) name(s) is/are passed\n  -restart: [service1 service2 ...]: restarts all services if no service(s) name(s) is/are passed\n  -prune: clear the system of all images, volumes, networks, containers, etc. (!this will remove ALL docker data)\n  -clean_cache: cleans the client's cached files (node_modules and bun cache)\n  -build_client: builds all files necessary for the client, you still need to run it yourself\n  -build_contracts: builds all contracts"
 	exit 22
 }
 
 start_services() {
-	# Build contracts
-	cd contracts && sozo build
-	cd ..
-	docker compose up -d --no-deps --build $@
+	local build_args=""
+	if [ $1 = true ]; then
+		shift 1
+		for service in "$@"; do
+			if [[ ! $(echo ${SERVICES[@]} | fgrep -w ${service}) ]]; then
+				help "restart"
+			fi
+			build_args+="--build-arg RESTART_$(echo ${service} | tr [a-z]- [A-Z]_ )=true "
+		done
+	fi
+	echo "👷 Building service(s)"
+	docker compose build ${build_args} $@
+	echo "▶️ Starting service(s)"
+	docker compose up -d --no-deps $@
 }
 
 stop_services() {
-	if [ ! -n $1 ]; then
-		help "stop"
-	fi
+	echo "🛑 Stopping service(s)"
 	docker-compose down $@
 }
 
-restart_service() {
-	if [ ! -n $1 ]; then
-		help "restart_service"
-	fi
-	service=$1
-	RESTART_SERVICE="RESTART_$(echo ${service} | tr [a-z] [A-Z])"
-	docker compose build --build-arg ${RESTART_SERVICE}=true ${service}
-	docker compose up -d --no-deps ${service}
-}
-
 prune_services() {
+	echo "🧹 pruning docker files"
 	docker system prune --all
 }
 
 clean_cache() {
+	echo "🧹 cleaning client cache"
 	rm -rf node_modules || rm -rf ./client/node_modules || rm -rf ~/.bun/install/cache
 }
 
+build_contracts() {
+	echo "📑 Building contrats"
+	cd contracts && sozo build
+}
+
 build_client() {
+	echo "👷 Building client"
 	clean_cache
 	bun install
 	bun run build-packages
@@ -48,21 +56,24 @@ build_client() {
 COMMAND=$1
 shift 1
 
+SERVICES=$@
+
 if [ $COMMAND = "start" ]; then
-	start_services $@
+	build_contracts
+	start_services $SERVICES
 elif [ $COMMAND = "stop" ]; then
-	stop_services $@
+	stop_services $SERVICES
 elif [ $COMMAND = "restart" ]; then
-	stop_services
-	start_services
+	stop_services $SERVICES
+	start_services true $SERVICES
 elif [ $COMMAND = "prune_docker" ]; then
 	prune_services
 elif [ $COMMAND = "clean_cache" ]; then
 	clean_cache
 elif [ $COMMAND = "build_client" ]; then
 	build_client
-elif [ $COMMAND = "restart_service" ]; then
-	restart_service $1
+elif [ $COMMAND = "build_contracts" ]; then
+	build_contracts
 else
 	help ${COMMAND}
 fi


### PR DESCRIPTION
This PR introduces a custom event whenever a trade is accepted. This helps greatly for subscriptions to events.

Other solutions were: 
- query all completed events and check if we didn't already have one or multiple in our database. This arguably could've been viable but to store each event and get the relevant data we needed to query different models (3 queries per unstored events).
- Subscribing to EntityUpdated, whenever a trade was created -> create a subscription for that trade and monitor it's status until it changes from `PENDING` to `COMPLETE`.  

These solutions did not seem really viable. I added the OrderAccepted event as I don't think it's invasive and will hopefully be useful for other people needing to monitor the market