### PR TITLE
Fixed issues with townhall history parsing.

### DIFF
--- a/client/src/components/cityview/realm/villagers/NpcChat.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcChat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef } from "react";
 import useWebSocket from "react-use-websocket";
 import { NpcChatMessage } from "./NpcChatMessage";
 import { StorageTownhalls, StorageTownhall, Message, NpcChatProps } from "./types";
@@ -11,13 +11,14 @@ const NpcChat = ({
   setSelectedTownhall,
   loadingTownhall,
   setLoadingTownhall,
+  lastMessageDisplayedIndex, 
+  setLastMessageDisplayedIndex
 }: NpcChatProps) => {
   const LOCAL_STORAGE_ID: string = `npc_chat_${realmId}`;
   const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(import.meta.env.VITE_OVERLORE_WS_URL, {
     share: false,
     shouldReconnect: () => true,
   });
-  const [lastMessageDisplayedIndex, setLastMessageDisplayedIndex] = useState(0);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -126,6 +127,7 @@ const NpcChat = ({
                       index={index}
                       lastMessageDisplayedIndex={lastMessageDisplayedIndex}
                       setLastMessageDisplayedIndex={setLastMessageDisplayedIndex}
+                      selectedTownhall={selectedTownhall}
                       bottomRef={bottomRef}
                       viewed={isViewed}
                       {...message}

--- a/client/src/components/cityview/realm/villagers/NpcChatMessage.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, RefObject } from "react";
+import { useState, useEffect, RefObject } from "react";
 
 const INTERKEY_STROKEN_DURATION_MS = 25;
 const CHARACTER_NUMBER_PER_LINE = 64;
@@ -8,6 +8,7 @@ export interface NpcChatMessageProps {
   dialogueSegment: string;
   index: number;
   setLastMessageDisplayedIndex: any;
+  selectedTownhall: number;
   viewed: boolean;
   bottomRef: RefObject<HTMLElement>;
 }
@@ -17,44 +18,45 @@ export function useTypingEffect(
   setLastMessageDisplayedIndex: any,
   bottomRef: RefObject<HTMLElement>,
   textToType: string,
+  selectedTownhall: number,
   interKeyStrokeDurationInMs: number,
 ) {
-  const [currentPosition, setCurrentPosition] = useState(0);
-  const currentPositionRef = useRef(0);
+  const [displayedText, setDisplayedText] = useState('');
 
   useEffect(() => {
+    setDisplayedText('');
+
     const intervalId = setInterval(() => {
-      setCurrentPosition((value) => value + 1);
-      currentPositionRef.current += 1;
-      if (currentPositionRef.current % CHARACTER_NUMBER_PER_LINE == 0) {
-        setTimeout(() => {
-          if (bottomRef.current) {
-            bottomRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
-          }
-        }, 1);
-      }
-      if (currentPositionRef.current > textToType.length) {
-        setLastMessageDisplayedIndex(msgIndex + 1);
+      setDisplayedText((prev) => {
+        if (prev.length < textToType.length) {
+          
+          if (prev.length % CHARACTER_NUMBER_PER_LINE == 0) {
+            setTimeout(() => {
+              if (bottomRef.current) {
+                bottomRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+              }
+            }, 1);
+          };
+          return textToType.slice(0, prev.length + 1);
+        } 
         clearInterval(intervalId);
-      }
+        setLastMessageDisplayedIndex(msgIndex + 1);
+        return prev;
+      });
     }, interKeyStrokeDurationInMs);
-    return () => {
-      clearInterval(intervalId);
-      currentPositionRef.current = 0;
-      setCurrentPosition(0);
-    };
-  }, [interKeyStrokeDurationInMs, textToType]);
-  if (textToType === undefined) {
-    return "";
-  }
-  return textToType.substring(0, currentPosition);
-}
+    return () => clearInterval(intervalId);
+  }, [msgIndex, textToType, setLastMessageDisplayedIndex, interKeyStrokeDurationInMs, selectedTownhall]);
+  if (textToType === undefined) return "";
+  return displayedText;
+};
+
 
 export const NpcChatMessage = (props: NpcChatMessageProps) => {
-  const { npcName, dialogueSegment, index, setLastMessageDisplayedIndex, bottomRef, viewed } = props;
+  const { npcName, dialogueSegment, index, setLastMessageDisplayedIndex, selectedTownhall, bottomRef, viewed } = props;
+  
   const typedDialogSegment = viewed
     ? dialogueSegment
-    : useTypingEffect(index, setLastMessageDisplayedIndex, bottomRef, dialogueSegment, INTERKEY_STROKEN_DURATION_MS);
+    : useTypingEffect(index, setLastMessageDisplayedIndex, bottomRef, dialogueSegment, selectedTownhall, INTERKEY_STROKEN_DURATION_MS);
 
   return (
     <div className="flex flex-col px-2 mb-3 py-1">

--- a/client/src/components/cityview/realm/villagers/NpcPanel.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcPanel.tsx
@@ -21,6 +21,7 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
   const [townHallRequest, setTownHallRequest] = useState(-1);
   const [selectedTownhall, setSelectedTownhall] = useState<number | null>(null);
   const [loadingTownhall, setLoadingTownhall] = useState<boolean>(false);
+  const [lastMessageDisplayedIndex, setLastMessageDisplayedIndex] = useState(0);
   const { realmId, realmEntityId } = useRealmStore();
 
   const parseTownhalls = (direction: string) => {
@@ -38,7 +39,10 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
       } else if (direction == "next" && currentKey >= 0 && currentKey < keys.length - 1) {
         newKey = keys[currentKey + 1];
       }
-      setSelectedTownhall(Number(newKey));
+      if (Number(newKey) != selectedTownhall) {
+        setLastMessageDisplayedIndex(0);
+        setSelectedTownhall(Number(newKey));
+      }
     }
   };
 
@@ -103,7 +107,10 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
         selectedTownhall={selectedTownhall}
         setSelectedTownhall={setSelectedTownhall}
         loadingTownhall={loadingTownhall} 
-        setLoadingTownhall={setLoadingTownhall} />
+        setLoadingTownhall={setLoadingTownhall}
+        lastMessageDisplayedIndex={lastMessageDisplayedIndex}
+        setLastMessageDisplayedIndex={setLastMessageDisplayedIndex} 
+        />
     </div>
   );
 };

--- a/client/src/components/cityview/realm/villagers/types.tsx
+++ b/client/src/components/cityview/realm/villagers/types.tsx
@@ -36,6 +36,8 @@ export type NpcChatProps = {
   setSelectedTownhall: (newIndex: number | null) => void;
   loadingTownhall: boolean;
   setLoadingTownhall: (loading: boolean) => void;
+  lastMessageDisplayedIndex: number;
+  setLastMessageDisplayedIndex: (newIndex: number) => void;
 }
 
 export type Message = {


### PR DESCRIPTION
We had some issues where, if a townhall discussion had not finished being rendered and we parsed through the townhall history, it would get stuck at the 1st segment or would display 3 lines at once.
From my testing, all of those have been fixed.
