### PR TITLE
Fixes a render issue during typing of a msg.

### DIFF
--- a/client/src/components/cityview/realm/villagers/NpcChat.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcChat.tsx
@@ -35,7 +35,7 @@ const NpcChat = ({ townHallRequest }: NpcChatProps) => {
     if (selectedTownhall === null) {
       return;
     }
-
+    setLastMessageDisplayedIndex(0);
     scrollToElement(topRef);
   }, [selectedTownhall]);
 


### PR DESCRIPTION
setLastMessageDisplayedIndex() must be called outside of the useTypingEffect hook for it to render correctly. 
Also, changed displayedDialogSegment to ALWAYS call useTypingEffect, otherwise the hooks calls differ and breaks.
wasAlreadyViewed check is moved inside useTypingEffect because of this.
