### PR TITLE
feat: include npcs in townhall request

### DIFF
--- a/client/src/components/cityview/realm/villagers/NpcChat.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcChat.tsx
@@ -35,7 +35,9 @@ const NpcChat = ({ LastWsMessage }: NpcChatProps) => {
   }, [selectedTownhall]);
 
   useEffect(() => {
-    scrollToElement(bottomRef);
+    if (lastMessageDisplayedIndex !== 0) {
+      scrollToElement(bottomRef);
+    }
 
     if (selectedTownhall === null) {
       return;
@@ -54,7 +56,6 @@ const NpcChat = ({ LastWsMessage }: NpcChatProps) => {
     setSelectedTownhall(townhallKey);
     setLoadingTownhall(false);
   }, [LastWsMessage]);
-
 
   useEffect(() => {}, []);
   return (

--- a/client/src/components/cityview/realm/villagers/NpcChat.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcChat.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useMemo } from "react";
-import useWebSocket from "react-use-websocket";
 import { NpcChatMessage } from "./NpcChatMessage";
 import { StorageTownhalls, StorageTownhall, TownhallResponse, NpcChatProps } from "./types";
 import useRealmStore from "../../../../hooks/store/useRealmStore";
@@ -7,7 +6,7 @@ import { getRealm } from "../../../../utils/realms";
 import { scrollToElement } from "./utils";
 import { useNpcContext } from "./NpcContext";
 
-const NpcChat = ({ townHallRequest }: NpcChatProps) => {
+const NpcChat = ({ LastWsMessage }: NpcChatProps) => {
   const {
     selectedTownhall,
     setSelectedTownhall,
@@ -19,10 +18,6 @@ const NpcChat = ({ townHallRequest }: NpcChatProps) => {
 
   const { realmId } = useRealmStore();
   const LOCAL_STORAGE_ID: string = `npc_chat_${realmId}`;
-  const { sendJsonMessage, lastJsonMessage, readyState } = useWebSocket(import.meta.env.VITE_OVERLORE_WS_URL, {
-    share: false,
-    shouldReconnect: () => true,
-  });
 
   const realm = useMemo(() => {
     return realmId ? getRealm(realmId) : undefined;
@@ -50,33 +45,16 @@ const NpcChat = ({ townHallRequest }: NpcChatProps) => {
   }, [lastMessageDisplayedIndex]);
 
   useEffect(() => {
-    if (lastJsonMessage === null) {
+    if (LastWsMessage === null) {
       return;
     }
 
     setLastMessageDisplayedIndex(0);
-
-    const townhallKey = addTownHallToStorage(lastJsonMessage as TownhallResponse, LOCAL_STORAGE_ID);
-
+    const townhallKey = addTownHallToStorage(LastWsMessage as TownhallResponse, LOCAL_STORAGE_ID);
     setSelectedTownhall(townhallKey);
-
     setLoadingTownhall(false);
-  }, [lastJsonMessage]);
+  }, [LastWsMessage]);
 
-  useEffect(() => {
-    if (townHallRequest === -1) {
-      return;
-    }
-
-    sendJsonMessage({
-      realm_id: realmId!.toString(),
-      orderId: realm!.order,
-    });
-  }, [townHallRequest]);
-
-  useEffect(() => {
-    console.log("Connection state changed");
-  }, [readyState]);
 
   useEffect(() => {}, []);
   return (

--- a/client/src/components/cityview/realm/villagers/NpcContext.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcContext.tsx
@@ -54,10 +54,9 @@ const getNpcs = (realmEntityId: BigInt, NpcComponent: any): Npc[] => {
   const entityIds = runQuery([HasValue(NpcComponent, { realm_id: realmEntityId })]);
   let npcs: Npc[] = Array.from(entityIds).map((entityId) => {
     let npc = getComponentValue(NpcComponent, entityId);
-
     return {
       entityId: entityId,
-      realmId: npc!.realm_id,
+      realmEntityId: Number(npc!.realm_id),
       characteristics: unpackCharacteristics(npc!.characteristics),
       characterTrait: shortString.decodeShortString(String(npc!.character_trait)),
       name: shortString.decodeShortString(String(npc!.name)),

--- a/client/src/components/cityview/realm/villagers/NpcPanel.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcPanel.tsx
@@ -85,9 +85,13 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
   }, [realmId]);
 
   const gatherVillagers = () => {
+    const npcsNoBigInt = npcs.map((npc): any => {
+      return { ...npc, entityId: npc.entityId.valueOf() };
+    });
     sendJsonMessage({
       realm_id: realmId!.toString(),
       orderId: realm!.order,
+      npcs: npcsNoBigInt,
     });
     setLoadingTownhall(true);
   };

--- a/client/src/components/cityview/realm/villagers/NpcPanel.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcPanel.tsx
@@ -85,13 +85,13 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
   }, [realmId]);
 
   const gatherVillagers = () => {
-    const npcsNoBigInt = npcs.map((npc): any => {
+    const npcsToSend = npcs.map((npc): any => {
       return { ...npc, entityId: npc.entityId.valueOf() };
     });
     sendJsonMessage({
       realm_id: realmId!.toString(),
       orderId: realm!.order,
-      npcs: npcsNoBigInt,
+      npcs: npcsToSend,
     });
     setLoadingTownhall(true);
   };

--- a/client/src/components/cityview/realm/villagers/NpcPanel.tsx
+++ b/client/src/components/cityview/realm/villagers/NpcPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import useWebSocket from "react-use-websocket";
 import Button from "../../../../elements/Button";
 import NpcChat from "./NpcChat";
 import useRealmStore from "../../../../hooks/store/useRealmStore";
@@ -15,6 +16,15 @@ type NpcPanelProps = {
 
 export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
   const {
+    sendJsonMessage,
+    lastJsonMessage: LastWsMessage,
+    readyState: wsReadyState,
+  } = useWebSocket(import.meta.env.VITE_OVERLORE_WS_URL, {
+    share: false,
+    shouldReconnect: () => true,
+  });
+
+  const {
     setup: {
       systemCalls: { spawn_npc },
     },
@@ -25,6 +35,10 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
   const { realmId, realmEntityId } = useRealmStore();
 
   const LOCAL_STORAGE_ID = `npc_chat_${realmId}`;
+
+  useEffect(() => {
+    console.log(`Connection state changed ${wsReadyState}`);
+  }, [wsReadyState]);
 
   const realm = useMemo(() => {
     return realmEntityId ? getRealm(realmId!) : undefined;
@@ -38,8 +52,6 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
     setLoadingTownhall,
     npcs,
   } = useNpcContext();
-
-  const [townHallRequest, setTownHallRequest] = useState(-1);
 
   const setSelectedTownhallFromDirection = (direction: number) => {
     const newKey = getNewTownhallKeyFromDirection(selectedTownhall, direction, LOCAL_STORAGE_ID);
@@ -73,7 +85,10 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
   }, [realmId]);
 
   const gatherVillagers = () => {
-    setTownHallRequest(townHallRequest + 1);
+    sendJsonMessage({
+      realm_id: realmId!.toString(),
+      orderId: realm!.order,
+    });
     setLoadingTownhall(true);
   };
 
@@ -101,7 +116,7 @@ export const NpcPanel = ({ type = "all" }: NpcPanelProps) => {
           </Button>
         </div>
       </div>
-      <NpcChat townHallRequest={townHallRequest} />
+      <NpcChat LastWsMessage={LastWsMessage} />
     </div>
   );
 };

--- a/client/src/components/cityview/realm/villagers/types.tsx
+++ b/client/src/components/cityview/realm/villagers/types.tsx
@@ -35,7 +35,7 @@ export type StorageTownhalls = {
 };
 
 export type NpcChatProps = {
-  townHallRequest: number;
+  LastWsMessage: any;
 };
 
 export type TownhallResponse = {

--- a/client/src/components/cityview/realm/villagers/types.tsx
+++ b/client/src/components/cityview/realm/villagers/types.tsx
@@ -14,7 +14,7 @@ export type Characteristics = {
 
 export type Npc = {
   entityId: BigNumberish;
-  realmId: Number;
+  realmEntityId: Number;
   characteristics: Characteristics;
   characterTrait: string;
   name: string;


### PR DESCRIPTION
Uses the real NPCs that are in the Realm to pass that data to lore-machine when requesting a town hall meeting

Closes #25 

Needs #41 to be merged first